### PR TITLE
Speedup instance serialize/deserialize

### DIFF
--- a/kphp_polyfills.php
+++ b/kphp_polyfills.php
@@ -615,7 +615,7 @@ function instance_deserialize(string $packed_str, string $type_of_instance): ?ob
   return _php_serialize_helper_run_or_warning(static function() use ($packed_str, $type_of_instance) {
     $unpacked_array = msgpack_deserialize_safe($packed_str);
 
-    $instance_parser = new KPHP\InstanceSerialization\InstanceParser($type_of_instance);
+    $instance_parser = new KPHP\InstanceSerialization\InstanceSerializer($type_of_instance);
     return $instance_parser->fromUnpackedArray($unpacked_array);
   });
 }

--- a/kphp_polyfills.php
+++ b/kphp_polyfills.php
@@ -615,7 +615,7 @@ function instance_deserialize(string $packed_str, string $type_of_instance): ?ob
   return _php_serialize_helper_run_or_warning(static function() use ($packed_str, $type_of_instance) {
     $unpacked_array = msgpack_deserialize_safe($packed_str);
 
-    $instance_parser = new KPHP\InstanceSerialization\InstanceSerializer($type_of_instance);
+    $instance_parser = new KPHP\InstanceSerialization\InstanceDeserializer($type_of_instance);
     return $instance_parser->fromUnpackedArray($unpacked_array);
   });
 }

--- a/src/InstanceSerialization/ArrayType.php
+++ b/src/InstanceSerialization/ArrayType.php
@@ -12,7 +12,7 @@ namespace KPHP\InstanceSerialization;
 use RuntimeException;
 
 class ArrayType extends PHPDocType {
-  /**@var PHPDocType|null */
+  /**@var ?PHPDocType */
   public $inner_type = null;
 
   /**@var int */
@@ -50,9 +50,7 @@ class ArrayType extends PHPDocType {
   }
 
   /**
-   * @param array       $arr
-   * @param UseResolver $use_resolver
-   * @return array
+   * @param mixed[] $arr
    * @throws RuntimeException
    */
   public function fromUnpackedValue($arr, UseResolver $use_resolver): array {

--- a/src/InstanceSerialization/ArrayType.php
+++ b/src/InstanceSerialization/ArrayType.php
@@ -54,41 +54,46 @@ class ArrayType extends PHPDocType {
    * @throws RuntimeException
    */
   public function fromUnpackedValue($arr, UseResolver $use_resolver): array {
-    if (is_array($arr) && !$this->hasInstanceInside()) {
+    if (!is_array($arr)) {
+      throw new RuntimeException('not instance: ' . $arr);
+    }
+
+    if (!$this->hasInstanceInside()) {
       return $arr;
     }
 
-    $value_collector = function($value) use ($use_resolver) {
-      return $this->inner_type->fromUnpackedValue($value, $use_resolver);
-    };
-    return $this->runOnEachValue($arr, $value_collector, $this->cnt_arrays);
+    $res = [];
+    foreach ($arr as $key => $value) {
+      if ($this->cnt_arrays === 1) {
+        $res[$key] = $this->inner_type->fromUnpackedValue($value, $use_resolver);
+      } else {
+        $this->cnt_arrays -= 1;
+        $res[$key] = $this->fromUnpackedValue($value, $use_resolver);
+        $this->cnt_arrays += 1;
+      }
+    }
+
+    return $res;
   }
 
   protected function hasInstanceInside(): bool {
     return $this->inner_type->hasInstanceInside();
   }
 
-  private function runOnEachValue($arr, callable $callback, int $cnt_arrays): array {
-    if (!is_array($arr)) {
-      throw new RuntimeException('not instance: ' . $arr);
+  public function verifyValueImpl($array, UseResolver $use_resolver): void {
+    if (!is_array($array)) {
+      throw new RuntimeException('not instance: ' . $array);
     }
 
-    $res = [];
-    foreach ($arr as $key => $value) {
-      $res[$key] = $cnt_arrays === 1
-        ? $callback($value)
-        : $this->runOnEachValue($value, $callback, $cnt_arrays - 1);
+    foreach ($array as $value) {
+      if ($this->cnt_arrays === 1) {
+        $this->inner_type->verifyValue($value, $use_resolver);
+      } else {
+        $this->cnt_arrays -= 1;
+        $this->verifyValueImpl($value, $use_resolver);
+        $this->cnt_arrays += 1;
+      }
     }
-
-    return $res;
-  }
-
-  public function verifyValueImpl($value, UseResolver $use_resolver): void {
-    $value_verifier = function($value) use ($use_resolver) {
-      $this->inner_type->verifyValue($value, $use_resolver);
-      return true;
-    };
-    $this->runOnEachValue($value, $value_verifier, $this->cnt_arrays);
   }
 }
 

--- a/src/InstanceSerialization/ArrayType.php
+++ b/src/InstanceSerialization/ArrayType.php
@@ -80,7 +80,7 @@ class ArrayType extends PHPDocType {
     return $this->inner_type->hasInstanceInside();
   }
 
-  public function verifyValueImpl($array, UseResolver $use_resolver): void {
+  public function verifyValue($array, UseResolver $use_resolver): void {
     if (!is_array($array)) {
       throw new RuntimeException('not instance: ' . $array);
     }
@@ -90,7 +90,7 @@ class ArrayType extends PHPDocType {
         $this->inner_type->verifyValue($value, $use_resolver);
       } else {
         $this->cnt_arrays -= 1;
-        $this->verifyValueImpl($value, $use_resolver);
+        $this->verifyValue($value, $use_resolver);
         $this->cnt_arrays += 1;
       }
     }

--- a/src/InstanceSerialization/ClassTransformer.php
+++ b/src/InstanceSerialization/ClassTransformer.php
@@ -34,7 +34,7 @@ class ClassTransformer implements CanPack {
       $packer = (new Packer(PackOptions::FORCE_STR | PackOptions::FORCE_FLOAT32))->extendWith(new ClassTransformer());
       return $packer->pack($instance->value);
     }
-    $instance_parser = new InstanceParser($instance);
+    $instance_parser = new InstanceSerializer($instance);
     return $packer->pack($instance_parser->tags_values);
   }
 }

--- a/src/InstanceSerialization/ClassTransformer.php
+++ b/src/InstanceSerialization/ClassTransformer.php
@@ -23,9 +23,7 @@ class ClassTransformer implements CanPack {
   public static $max_depth = 20;
 
   /**
-   * @param Packer $packer
    * @param object $instance
-   * @return string|null
    * @throws ReflectionException
    * @throws RuntimeException
    */

--- a/src/InstanceSerialization/FieldMetadata.php
+++ b/src/InstanceSerialization/FieldMetadata.php
@@ -1,0 +1,23 @@
+<?php
+// Compiler for PHP (aka KPHP) polyfills
+// Copyright (c) 2020 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+namespace KPHP\InstanceSerialization;
+
+class FieldMetadata {
+  /** @var int */
+  public $id = 0;
+
+  /**@var string */
+  public $name = "";
+
+  /**@var string */
+  public $type = "";
+
+  /**@var PHPDocType */
+  public $phpdoc_type = null;
+
+  /**@var bool */
+  public $as_float32 = false;
+}

--- a/src/InstanceSerialization/InstanceDeserializer.php
+++ b/src/InstanceSerialization/InstanceDeserializer.php
@@ -1,0 +1,73 @@
+<?php
+// Compiler for PHP (aka KPHP) polyfills
+// Copyright (c) 2020 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+/** @noinspection NoTypeDeclarationInspection */
+/** @noinspection KphpReturnTypeMismatchInspection */
+/** @noinspection KphpParameterTypeMismatchInspection */
+
+namespace KPHP\InstanceSerialization;
+
+use ReflectionClass;
+use ReflectionException;
+use ReflectionProperty;
+use RuntimeException;
+
+class InstanceDeserializer {
+  /** @var InstanceMetadata */
+  public $instance_metadata;
+
+  /**
+   * InstanceParser constructor.
+   * @throws ReflectionException
+   * @throws RuntimeException
+   */
+  public function __construct(string $instance) {
+    assert($instance !== '' && $instance !== 'self');
+    $this->instance_metadata = InstanceMetadataCache::getInstanceMetadata($instance);
+  }
+
+  /**
+   * @param array|null $unpacked_arr
+   * @return object|null
+   * @throws ReflectionException
+   * @throws RuntimeException
+   */
+  public function fromUnpackedArray($unpacked_arr): ?object {
+    if ($unpacked_arr === null) {
+      return null;
+    }
+
+    if (!is_array($unpacked_arr)) {
+      throw new RuntimeException('Expected NIL or ARRAY type for unpacking class_instance');
+    }
+
+    $instance        = $this->instance_metadata->reflection_of_instance->newInstanceWithoutConstructor();
+    $rc_for_instance = new ReflectionClass($instance);
+
+    for ($i = 0, $i_max = count($unpacked_arr); $i < $i_max; $i += 2) {
+      $cur_tag   = (int)$unpacked_arr[$i];
+      $cur_value = $unpacked_arr[$i + 1];
+
+      $cur_idx  = array_search($cur_tag, $this->instance_metadata->field_ids, true);
+      if ($cur_idx === false) {
+        continue;
+      }
+      $cur_type = $this->instance_metadata->phpdoc_types[$cur_idx];
+      $cur_name = $this->instance_metadata->names[$cur_idx];
+
+      $cur_value = $cur_type->fromUnpackedValue($cur_value, $this->instance_metadata->use_resolver);
+      $this->setValue($rc_for_instance->getProperty($cur_name), $instance, $cur_value);
+    }
+
+    return $instance;
+  }
+
+  private function setValue(ReflectionProperty $property, object $instance, $value): void {
+    $is_accessible = $property->isPrivate() || $property->isProtected();
+    $property->setAccessible(true);
+    $property->setValue($instance, $value);
+    $property->setAccessible($is_accessible);
+  }
+}

--- a/src/InstanceSerialization/InstanceDeserializer.php
+++ b/src/InstanceSerialization/InstanceDeserializer.php
@@ -48,15 +48,13 @@ class InstanceDeserializer {
       $cur_tag   = (int)$unpacked_arr[$i];
       $cur_value = $unpacked_arr[$i + 1];
 
-      $cur_idx  = array_search($cur_tag, $this->instance_metadata->field_ids, true);
-      if ($cur_idx === false) {
-        continue;
+      foreach ($this->instance_metadata->fields_data as $field) {
+        if ($field->id == $cur_tag) {
+          $cur_value = $field->phpdoc_type->fromUnpackedValue($cur_value, $this->instance_metadata->use_resolver);
+          $this->setValue($rc_for_instance->getProperty($field->name), $instance, $cur_value);
+          break;
+        }
       }
-      $cur_type = $this->instance_metadata->phpdoc_types[$cur_idx];
-      $cur_name = $this->instance_metadata->names[$cur_idx];
-
-      $cur_value = $cur_type->fromUnpackedValue($cur_value, $this->instance_metadata->use_resolver);
-      $this->setValue($rc_for_instance->getProperty($cur_name), $instance, $cur_value);
     }
 
     return $instance;

--- a/src/InstanceSerialization/InstanceDeserializer.php
+++ b/src/InstanceSerialization/InstanceDeserializer.php
@@ -65,9 +65,7 @@ class InstanceDeserializer {
   }
 
   private function setValue(ReflectionProperty $property, object $instance, $value): void {
-    $is_accessible = $property->isPrivate() || $property->isProtected();
     $property->setAccessible(true);
     $property->setValue($instance, $value);
-    $property->setAccessible($is_accessible);
   }
 }

--- a/src/InstanceSerialization/InstanceDeserializer.php
+++ b/src/InstanceSerialization/InstanceDeserializer.php
@@ -46,22 +46,20 @@ class InstanceDeserializer {
 
     for ($i = 0, $i_max = count($unpacked_arr); $i < $i_max; $i += 2) {
       $cur_tag   = (int)$unpacked_arr[$i];
-      $cur_value = $unpacked_arr[$i + 1];
+      $value = $unpacked_arr[$i + 1];
 
       foreach ($this->instance_metadata->fields_data as $field) {
         if ($field->id == $cur_tag) {
-          $cur_value = $field->phpdoc_type->fromUnpackedValue($cur_value, $this->instance_metadata->use_resolver);
-          $this->setValue($rc_for_instance->getProperty($field->name), $instance, $cur_value);
+          $value = $field->phpdoc_type->fromUnpackedValue($value, $this->instance_metadata->use_resolver);
+
+          $property = $rc_for_instance->getProperty($field->name);
+          $property->setAccessible(true);
+          $property->setValue($instance, $value);
           break;
         }
       }
     }
 
     return $instance;
-  }
-
-  private function setValue(ReflectionProperty $property, object $instance, $value): void {
-    $property->setAccessible(true);
-    $property->setValue($instance, $value);
   }
 }

--- a/src/InstanceSerialization/InstanceDeserializer.php
+++ b/src/InstanceSerialization/InstanceDeserializer.php
@@ -29,12 +29,10 @@ class InstanceDeserializer {
   }
 
   /**
-   * @param array|null $unpacked_arr
-   * @return object|null
    * @throws ReflectionException
    * @throws RuntimeException
    */
-  public function fromUnpackedArray($unpacked_arr): ?object {
+  public function fromUnpackedArray(?array $unpacked_arr): ?object {
     if ($unpacked_arr === null) {
       return null;
     }

--- a/src/InstanceSerialization/InstanceMetadata.php
+++ b/src/InstanceSerialization/InstanceMetadata.php
@@ -14,27 +14,14 @@ use ReflectionException;
 use RuntimeException;
 
 class InstanceMetadata {
-
-  /**@var string[] */
-  public $names = [];
-
-  /**@var string[] */
-  public $types = [];
-
-  /**@var PHPDocType[] */
-  public $phpdoc_types = [];
+  /**@var FieldMetadata[] */
+  public $fields_data = [];
 
   /**@var ?ReflectionClass */
   public $reflection_of_instance = null;
 
   /**@var ?UseResolver */
   public $use_resolver = null;
-
-  /** @var int[] */
-  public $field_ids = [];
-
-  /**@var bool[] */
-  public $as_float32 = [];
 
   /**
    * @throws ReflectionException
@@ -59,58 +46,59 @@ class InstanceMetadata {
     $reserved_field_ids = array_map('intval', $reserved_field_ids);
 
     foreach ($this->reflection_of_instance->getProperties() as $property) {
-      preg_match('/@kphp-serialized-field\s+(\d+|none)[\s*]/', $property->getDocComment(), $matches);
+      $curDocComment = $property->getDocComment();
+      $curName = $property->getName();
+      preg_match('/@kphp-serialized-field\s+(\d+|none)[\s*]/', $curDocComment, $matches);
 
       if ($property->isStatic()) {
         if ($matches) {
-          throw new RuntimeException('@kphp-serialized-field tag is forbidden for static fields: ' . $property->getName());
+          throw new RuntimeException('@kphp-serialized-field tag is forbidden for static fields: ' . $curName);
         }
         continue;
       }
 
       if (count($matches) <= 1) {
-        throw new RuntimeException('You should add @kphp-serialized-field phpdoc to field: ' . $property->getName());
+        throw new RuntimeException('You should add @kphp-serialized-field phpdoc to field: ' . $curName);
       }
 
       if ($matches[1] === 'none') {
         continue;
       }
       assert(is_numeric($matches[1]));
-      $matches[1] = (int)$matches[1];
+      $field = new FieldMetadata();
+      $field->id = (int)$matches[1];
 
-      if ($matches[1] < 0 || 127 < $matches[1]) {
-        throw new RuntimeException("id=${matches[1]} is not in the range [0, 127], field: " . $property->getName());
+      if ($field->id < 0 || 127 < $field->id) {
+        throw new RuntimeException("id=${matches[1]} is not in the range [0, 127], field: " . $curName);
       }
 
-      if (in_array($matches[1], $reserved_field_ids, true)) {
-        throw new RuntimeException("id=${matches[1]} is already in use, field: " . $property->getName());
+      if (in_array($field->id, $reserved_field_ids, true)) {
+        throw new RuntimeException("id=${matches[1]} is already in use, field: " . $curName);
       }
-      $reserved_field_ids[] = $matches[1];
-      $this->field_ids[] = $matches[1];
+      $reserved_field_ids[] = $field->id;
 
-      $this->names[] = $property->getName();
+      $field->name = $curName;
 
-      $this->as_float32[] = strpos($property->getDocComment(), '@kphp-serialized-float32') !== false;
+      $field->as_float32 = strpos($curDocComment, '@kphp-serialized-float32') !== false;
 
       // get type either from @var or from php 7.4 field type hint
-      $type = '';
-      preg_match('/@var\s+([^\n]+)/', $property->getDocComment(), $matches);
+      preg_match('/@var\s+([^\n]+)/', $curDocComment, $matches);
       if (count($matches) > 1) {
-        $type = (string)$matches[1];
+        $field->type = (string)$matches[1];
       } else if (PHP_VERSION_ID >= 70400 && $property->hasType()) {
-        $type = ($property->getType()->allowsNull() ? '?' : '') . $property->getType();
+        $type = $property->getType();
+        $field->type = ($type ? '?' : '') . $type;
       }
-      if ($type === '') {
-        throw new RuntimeException("Can't detect type of field {$property->getName()}");
+      if ($field->type === '') {
+        throw new RuntimeException("Can't detect type of field {$curName}");
       }
 
-      $type_copy = $type;
-      $parsed_phpdoc = PHPDocType::parse($type_copy);
-      if ($parsed_phpdoc === null) {
-        throw new RuntimeException("Can't parse phpdoc of field {$property->getName()}: {$type}");
+      $type_copy = $field->type;
+      $field->phpdoc_type = PHPDocType::parse($type_copy);
+      if ($field->phpdoc_type === null) {
+        throw new RuntimeException("Can't parse phpdoc of field {$curName}: {$field->type}");
       }
-      $this->types[] = $type;
-      $this->phpdoc_types[] = $parsed_phpdoc;
+      $this->fields_data[] = $field;
     }
   }
 }

--- a/src/InstanceSerialization/InstanceMetadata.php
+++ b/src/InstanceSerialization/InstanceMetadata.php
@@ -24,10 +24,10 @@ class InstanceMetadata {
   /**@var PHPDocType[] */
   public $phpdoc_types = [];
 
-  /**@var ReflectionClass|null */
+  /**@var ?ReflectionClass */
   public $reflection_of_instance = null;
 
-  /**@var UseResolver|null */
+  /**@var ?UseResolver */
   public $use_resolver = null;
 
   /** @var int[] */

--- a/src/InstanceSerialization/InstanceMetadataCache.php
+++ b/src/InstanceSerialization/InstanceMetadataCache.php
@@ -14,15 +14,8 @@ class InstanceMetadataCache {
   /** @var InstanceMetadata[] */
   private static $instance_parsers = [];
 
-  /**
-   * @param object|string $class_name
-   * @return InstanceMetadata
-   * @throws \ReflectionException
-   */
-  public static function getInstanceParser($class_name): InstanceMetadata {
-    if (is_object($class_name)) {
-      $class_name = get_class($class_name);
-    }
+  /** @throws \ReflectionException */
+  public static function getInstanceMetadata(string $class_name): InstanceMetadata {
     if (!array_key_exists($class_name, self::$instance_parsers)) {
       self::$instance_parsers[$class_name] = new InstanceMetadata($class_name);
     }

--- a/src/InstanceSerialization/InstanceMetadataCache.php
+++ b/src/InstanceSerialization/InstanceMetadataCache.php
@@ -9,12 +9,14 @@
 
 namespace KPHP\InstanceSerialization;
 
+use ReflectionException;
+
 class InstanceMetadataCache {
 
   /** @var InstanceMetadata[] */
   private static $instance_parsers = [];
 
-  /** @throws \ReflectionException */
+  /** @throws ReflectionException */
   public static function getInstanceMetadata(string $class_name): InstanceMetadata {
     if (!array_key_exists($class_name, self::$instance_parsers)) {
       self::$instance_parsers[$class_name] = new InstanceMetadata($class_name);

--- a/src/InstanceSerialization/InstanceSerializer.php
+++ b/src/InstanceSerialization/InstanceSerializer.php
@@ -9,9 +9,7 @@
 
 namespace KPHP\InstanceSerialization;
 
-use ReflectionClass;
 use ReflectionException;
-use ReflectionProperty;
 use RuntimeException;
 
 class InstanceSerializer {
@@ -22,28 +20,23 @@ class InstanceSerializer {
   public $instance_metadata;
 
   /**
-   * InstanceSerializer constructor.
-   * @param object|string $instance
    * @throws ReflectionException
    * @throws RuntimeException
    */
-  public function __construct($instance) {
+  public function __construct(object $instance) {
     ClassTransformer::$depth++;
     if (ClassTransformer::$depth > ClassTransformer::$max_depth) {
       throw new RuntimeException('maximum depth of nested instances exceeded');
     }
 
-    assert(is_object($instance) || (is_string($instance) && $instance !== '' && $instance !== 'self'));
-    $this->instance_metadata = InstanceMetadataCache::getInstanceParser($instance);
+    $this->instance_metadata = InstanceMetadataCache::getInstanceMetadata(get_class($instance));
 
     foreach ($this->instance_metadata->names as $i => $name) {
       $this->tags_values[] = $this->instance_metadata->field_ids[$i];
-      $current_value = is_object($instance) ? $this->getValue($i, (object)$instance) : null;
+      $current_value = $this->getValue($i, $instance);
       $this->tags_values[] = $current_value;
 
-      if (is_object($instance)) {
-        $this->checkTypeOf($this->instance_metadata->phpdoc_types[$i], $this->instance_metadata->types[$i], $this->instance_metadata->names[$i], $current_value);
-      }
+      $this->checkTypeOf($this->instance_metadata->phpdoc_types[$i], $this->instance_metadata->types[$i], $this->instance_metadata->names[$i], $current_value);
     }
 
     ClassTransformer::$depth--;
@@ -65,47 +58,6 @@ class InstanceSerializer {
   }
 
   /**
-   * @param array|null $unpacked_arr
-   * @return object|null
-   * @throws ReflectionException
-   * @throws RuntimeException
-   */
-  public function fromUnpackedArray($unpacked_arr): ?object {
-    if ($unpacked_arr === null) {
-      return null;
-    }
-
-    if (!is_array($unpacked_arr)) {
-      throw new RuntimeException('Expected NIL or ARRAY type for unpacking class_instance');
-    }
-
-    $instance        = $this->instance_metadata->reflection_of_instance->newInstanceWithoutConstructor();
-    $rc_for_instance = new ReflectionClass($instance);
-
-    $is_even = static function($key) {
-      return $key % 2 === 0;
-    };
-    $tags    = array_values(array_filter($this->tags_values, $is_even, ARRAY_FILTER_USE_KEY));
-
-    for ($i = 0, $i_max = count($unpacked_arr); $i < $i_max; $i += 2) {
-      $cur_tag   = (int)$unpacked_arr[$i];
-      $cur_value = $unpacked_arr[$i + 1];
-
-      $cur_idx  = array_search($cur_tag, $tags, true);
-      if ($cur_idx === false) {
-        continue;
-      }
-      $cur_type = $this->instance_metadata->phpdoc_types[$cur_idx];
-      $cur_name = $this->instance_metadata->names[$cur_idx];
-
-      $cur_value = $cur_type->fromUnpackedValue($cur_value, $this->instance_metadata->use_resolver);
-      $this->setValue($rc_for_instance->getProperty($cur_name), $instance, $cur_value);
-    }
-
-    return $instance;
-  }
-
-  /**
    * @return mixed|DeepForceFloat32
    * @throws ReflectionException
    */
@@ -120,12 +72,5 @@ class InstanceSerializer {
       return new DeepForceFloat32($result);
     }
     return $result;
-  }
-
-  private function setValue(ReflectionProperty $property, object $instance, $value): void {
-    $is_accessible = $property->isPrivate() || $property->isProtected();
-    $property->setAccessible(true);
-    $property->setValue($instance, $value);
-    $property->setAccessible($is_accessible);
   }
 }

--- a/src/InstanceSerialization/InstanceSerializer.php
+++ b/src/InstanceSerialization/InstanceSerializer.php
@@ -14,7 +14,7 @@ use ReflectionException;
 use ReflectionProperty;
 use RuntimeException;
 
-class InstanceParser {
+class InstanceSerializer {
   /**@var (mixed|DeepForceFloat32)[] */
   public $tags_values = [];
 
@@ -22,7 +22,7 @@ class InstanceParser {
   public $instance_metadata;
 
   /**
-   * InstanceParser constructor.
+   * InstanceSerializer constructor.
    * @param object|string $instance
    * @throws ReflectionException
    * @throws RuntimeException

--- a/src/InstanceSerialization/InstanceSerializer.php
+++ b/src/InstanceSerialization/InstanceSerializer.php
@@ -63,10 +63,8 @@ class InstanceSerializer {
    */
   private function getValue(int $property_id, object $instance) {
     $property = $this->instance_metadata->reflection_of_instance->getProperty($this->instance_metadata->names[$property_id]);
-    $is_accessible = $property->isPrivate() || $property->isProtected();
     $property->setAccessible(true);
     $result = $property->getValue($instance);
-    $property->setAccessible($is_accessible);
 
     if ($this->instance_metadata->as_float32[$property_id]) {
       return new DeepForceFloat32($result);

--- a/src/InstanceSerialization/InstanceSerializer.php
+++ b/src/InstanceSerialization/InstanceSerializer.php
@@ -32,11 +32,11 @@ class InstanceSerializer {
     $this->instance_metadata = InstanceMetadataCache::getInstanceMetadata(get_class($instance));
 
     foreach ($this->instance_metadata->fields_data as $field) {
-      $this->tags_values[] = $field->id;
       $current_value = $this->getValue($field, $instance);
-      $this->tags_values[] = $current_value;
-
       $this->checkTypeOf($field, $current_value);
+
+      $this->tags_values[] = $field->id;
+      $this->tags_values[] = $field->as_float32 ? new DeepForceFloat32($current_value) : $current_value;
     }
 
     ClassTransformer::$depth--;
@@ -56,17 +56,12 @@ class InstanceSerializer {
   }
 
   /**
-   * @return mixed|DeepForceFloat32
+   * @return mixed
    * @throws ReflectionException
    */
   private function getValue(FieldMetadata $field, object $instance) {
     $property = $this->instance_metadata->reflection_of_instance->getProperty($field->name);
     $property->setAccessible(true);
-    $result = $property->getValue($instance);
-
-    if ($field->as_float32) {
-      return new DeepForceFloat32($result);
-    }
-    return $result;
+    return $property->getValue($instance);
   }
 }

--- a/src/InstanceSerialization/InstanceType.php
+++ b/src/InstanceSerialization/InstanceType.php
@@ -33,9 +33,8 @@ class InstanceType extends PHPDocType {
   }
 
   /**
-   * @param array|null  $value
-   * @param UseResolver $use_resolver
-   * @return object|null
+   * @param ?array $value
+   * @return ?object
    * @throws ReflectionException
    * @throws RuntimeException
    */
@@ -55,8 +54,6 @@ class InstanceType extends PHPDocType {
 
   /**
    * @param mixed       $value
-   * @param UseResolver $use_resolver
-   * @return void
    * @throws ReflectionException
    */
   public function verifyValueImpl($value, UseResolver $use_resolver): void {

--- a/src/InstanceSerialization/InstanceType.php
+++ b/src/InstanceSerialization/InstanceType.php
@@ -41,7 +41,7 @@ class InstanceType extends PHPDocType {
    */
   public function fromUnpackedValue($value, UseResolver $use_resolver) {
     $resolved_class_name = $this->getResolvedClassName($use_resolver);
-    $parser              = new InstanceSerializer($resolved_class_name);
+    $parser              = new InstanceDeserializer($resolved_class_name);
     return $parser->fromUnpackedArray($value);
   }
 

--- a/src/InstanceSerialization/InstanceType.php
+++ b/src/InstanceSerialization/InstanceType.php
@@ -41,7 +41,7 @@ class InstanceType extends PHPDocType {
    */
   public function fromUnpackedValue($value, UseResolver $use_resolver) {
     $resolved_class_name = $this->getResolvedClassName($use_resolver);
-    $parser              = new InstanceParser($resolved_class_name);
+    $parser              = new InstanceSerializer($resolved_class_name);
     return $parser->fromUnpackedArray($value);
   }
 
@@ -70,7 +70,7 @@ class InstanceType extends PHPDocType {
 
     $resolved_name = $this->getResolvedClassName($use_resolver);
     $rc            = new ReflectionClass($resolved_name);
-    $parser        = new InstanceParser($value); // will verify values inside $value
+    $parser        = new InstanceSerializer($value); // will verify values inside $value
     if ($parser->instance_metadata->reflection_of_instance->getName() !== $rc->getName()) {
       self::throwRuntimeException($rc->getName(), $this->type);
     }

--- a/src/InstanceSerialization/InstanceType.php
+++ b/src/InstanceSerialization/InstanceType.php
@@ -56,7 +56,7 @@ class InstanceType extends PHPDocType {
    * @param mixed       $value
    * @throws ReflectionException
    */
-  public function verifyValueImpl($value, UseResolver $use_resolver): void {
+  public function verifyValue($value, UseResolver $use_resolver): void {
     if ($value === null) {
       return;
     }

--- a/src/InstanceSerialization/OrType.php
+++ b/src/InstanceSerialization/OrType.php
@@ -36,7 +36,7 @@ class OrType extends PHPDocType {
     }
   }
 
-  public function verifyValueImpl($value, UseResolver $use_resolver): void {
+  public function verifyValue($value, UseResolver $use_resolver): void {
     try {
       $this->type1->verifyValue($value, $use_resolver);
     } catch (Throwable $_) {

--- a/src/InstanceSerialization/PHPDocType.php
+++ b/src/InstanceSerialization/PHPDocType.php
@@ -84,7 +84,6 @@ abstract class PHPDocType {
 
   /**
    * @param mixed       $value
-   * @param UseResolver $use_resolver
    * @return mixed
    * @throws RuntimeException
    */
@@ -92,7 +91,6 @@ abstract class PHPDocType {
 
   /**
    * @param mixed       $value
-   * @param UseResolver $use_resolver
    * @throws RuntimeException
    */
   public function verifyValue($value, UseResolver $use_resolver): void {
@@ -105,7 +103,6 @@ abstract class PHPDocType {
 
   /**
    * @param mixed       $value
-   * @param UseResolver $use_resolver
    * @throws RuntimeException
    */
   abstract public function verifyValueImpl($value, UseResolver $use_resolver): void;

--- a/src/InstanceSerialization/PHPDocType.php
+++ b/src/InstanceSerialization/PHPDocType.php
@@ -83,29 +83,17 @@ abstract class PHPDocType {
   }
 
   /**
-   * @param mixed       $value
+   * @param mixed $value
    * @return mixed
    * @throws RuntimeException
    */
   abstract public function fromUnpackedValue($value, UseResolver $use_resolver);
 
   /**
-   * @param mixed       $value
+   * @param mixed $value
    * @throws RuntimeException
    */
-  public function verifyValue($value, UseResolver $use_resolver): void {
-    if ($value instanceof DeepForceFloat32) {
-      $this->verifyValueImpl($value->value, $use_resolver);
-    } else {
-      $this->verifyValueImpl($value, $use_resolver);
-    }
-  }
-
-  /**
-   * @param mixed       $value
-   * @throws RuntimeException
-   */
-  abstract public function verifyValueImpl($value, UseResolver $use_resolver): void;
+  abstract public function verifyValue($value, UseResolver $use_resolver): void;
 
   abstract protected function hasInstanceInside(): bool;
 }

--- a/src/InstanceSerialization/PrimitiveType.php
+++ b/src/InstanceSerialization/PrimitiveType.php
@@ -37,7 +37,6 @@ class PrimitiveType extends PHPDocType {
 
   /**
    * @param mixed       $value
-   * @param UseResolver $use_resolver
    * @return mixed
    * @throws RuntimeException
    */

--- a/src/InstanceSerialization/PrimitiveType.php
+++ b/src/InstanceSerialization/PrimitiveType.php
@@ -66,7 +66,7 @@ class PrimitiveType extends PHPDocType {
     return $this->type;
   }
 
-  public function verifyValueImpl($value, UseResolver $_): void {
+  public function verifyValue($value, UseResolver $_): void {
     $true_type = $this->getPHPCompliantType();
     if (gettype($value) === $true_type) {
       if (($this->type === 'true' && $value !== true) ||

--- a/src/InstanceSerialization/TupleType.php
+++ b/src/InstanceSerialization/TupleType.php
@@ -63,7 +63,7 @@ class TupleType extends PHPDocType {
   }
 
   /** @param mixed $value */
-  public function verifyValueImpl($value, UseResolver $use_resolver): void {
+  public function verifyValue($value, UseResolver $use_resolver): void {
     $this->checkValue($value);
     for ($i = 0, $i_max = count($value); $i < $i_max; $i++) {
       $this->types[$i]->verifyValue($value[$i], $use_resolver);

--- a/src/InstanceSerialization/TupleType.php
+++ b/src/InstanceSerialization/TupleType.php
@@ -20,11 +20,7 @@ class TupleType extends PHPDocType {
     $this->types = $types;
   }
 
-  /**
-   * @param string $str
-   * @return PHPDocType|null
-   * @throws RuntimeException
-   */
+  /** @throws RuntimeException */
   protected static function parseImpl(string &$str): ?PHPDocType {
     if (!parent::removeIfStartsWith($str, '\\tuple(') && !parent::removeIfStartsWith($str, 'tuple(')) {
       return null;
@@ -53,9 +49,7 @@ class TupleType extends PHPDocType {
   }
 
   /**
-   * @param mixed       $value
-   * @param UseResolver $use_resolver
-   * @return array
+   * @param mixed $value
    * @throws RuntimeException
    */
   public function fromUnpackedValue($value, UseResolver $use_resolver): array {

--- a/src/InstanceSerialization/UseResolver.php
+++ b/src/InstanceSerialization/UseResolver.php
@@ -10,11 +10,10 @@
 namespace KPHP\InstanceSerialization;
 
 use ReflectionClass;
-use ReflectionException;
 use SplFileObject;
 
 class UseResolver {
-  /**@var ReflectionClass|null */
+  /**@var ?ReflectionClass */
   private $instance_reflection = null;
 
   /**@var string[] */
@@ -29,10 +28,6 @@ class UseResolver {
   /**@var int */
   private $token_id = -1;
 
-  /**
-   * UseResolver constructor.
-   * @throws ReflectionException
-   */
   public function __construct(ReflectionClass $instance_reflection) {
     $this->instance_reflection = $instance_reflection;
 


### PR DESCRIPTION
In the PR you can find refactoring and several optimizations to serialize/deserialize instances with msgpack.
It's better to review it commit by commit.

On top of different optimizations new parameter for `instance_serialize` is present - `$verify_values_in_PHP`. Which can be `false` to simply disable all type-checks of fields inside of classes and only serialize it. As KPHP makes these checks on compile-time, they are not necessary for PHP if you are 100% sure of what you are doing. Or you can add it to the final stage. It drastically decreases the time for serialization on PHP.

Here you can find [source of the benchmark](https://pastebin.com/tr0pabTz). It's an auto-generated class that contains one array of floats and 100 instances with tuple inside.

The test was performed 20 times and time was measured for all runs. The table below shows `ministat` output on 4 versions for the same test on `instance_serialize` function. 
`old`, `new`, `kphp` - are self-explanatory names. `ver` - it's version when we use `instance_serialize` with parameter `verify_values_in_PHP=false`

```
serialization
        N           Min           Max        Median           Avg        Stddev
old     20     4.3419039      4.539355      4.485919     4.4733123   0.061731518
new     20     2.7661021     3.0326209     2.9318218     2.9211529   0.068796329
ver     20      1.291374      1.374531     1.3209579     1.3226826   0.023579538
kphp    20 0.00098276138  0.0041151047  0.0019631386  0.0022862554  0.0012370711
```

According to median measures `instance_serialize` with the PR works **1.53 times faster** than it used to and **3.4 times faster** if you disable type verification.

The table below shows measures for `instance_deserialize` function.
```
deserialization
      N           Min           Max        Median           Avg        Stddev
old   20     2.8013561      3.030751     2.9693692     2.9449946   0.064492363
new   20     1.8812442     2.2569361     1.9203191     1.9419845   0.079000496
kphp  20  0.0017907619  0.0077209473  0.0035014153  0.0038653016  0.0018846356
```

According to median measures, `instance_deserialize` with the PR works **1.55 times faster** than it used to.