### PR TITLE
print more readable error msg in case of type mismatch

### DIFF
--- a/src/InstanceSerialization/InstanceSerializer.php
+++ b/src/InstanceSerialization/InstanceSerializer.php
@@ -50,8 +50,7 @@ class InstanceSerializer {
       if (ClassTransformer::$depth > ClassTransformer::$max_depth) {
         throw $e;
       }
-      $value = vk_json_encode($value);
-      throw new RuntimeException("value: `${value}` from field: `{$field->name}` doesn't correspond to type: `{$field->type}`", 0, $e);
+      throw new RuntimeException("in field: `{$field->name}` -> " . $e->getMessage(), 0);
     }
   }
 


### PR DESCRIPTION
chain all places from the place where an error occurs with an original error message to clarify the problem more precisely.

see an example on the screenshot below.

![image](https://user-images.githubusercontent.com/5980005/113708431-e2b52200-96e9-11eb-8623-8c069e8bc5b8.png)
