### PR TITLE
Fix TupleType::hasInstanceInside infinite recursion.

### DIFF
--- a/src/InstanceSerialization/TupleType.php
+++ b/src/InstanceSerialization/TupleType.php
@@ -71,7 +71,7 @@ class TupleType extends PHPDocType {
   }
 
   protected function hasInstanceInside(): bool {
-    return in_array(true, array_map([$this, 'hasInstanceInside'], $this->types), true);
+    return in_array(true, array_map(fn(PHPDocType $type) => $type->hasInstanceInside(), $this->types), true);
   }
 
   /** @param mixed $value */


### PR DESCRIPTION
`hasInstanceInside` was called on `this` instead of array element.

Call ```array_map([$this, 'hasInstanceInside'], $this->types)``` was equivalent to following:
```php
$result = []
foreach ($this->types as $type) {
  $result[] = $this->hasInstanceInside(); // Bug, $type->hasInstanceInside() is expected.
}
return $result;
```