### PR TITLE
added estimate_memory_usage() function

### DIFF
--- a/kphp_polyfills.php
+++ b/kphp_polyfills.php
@@ -1024,3 +1024,12 @@ function set_migration_php8_warning(int $mask): void {}
 
 
 #endif
+
+/**
+ * Gives a ballpark size estimate of the given value, in bytes.
+ * Results may differ greatly from KPHP
+ */
+function estimate_memory_usage($value, int $depth = 0): int {
+  // works 10x times faster than iterating over array elements, reflection on objects etc.
+  return strlen(serialize($value));
+}


### PR DESCRIPTION
Added missing function `estimate_memory_usage()`. Main intent is to polyfill, not to copy exact KPHP behaviour for this. 

I've tried different implementations of size estimation like iterating/recursing over given data structure, but they proved to be 5-20x times slower than serialize(). json_encode() is also fast and gave promising estimations, but could fail on some input and don't work with non utf8 strings correctly. 