### PR TITLE
moved KPHP_COMPILER_VERSION to polyfills

### DIFF
--- a/kphp_polyfills.php
+++ b/kphp_polyfills.php
@@ -24,6 +24,11 @@
 
 #ifndef KPHP  // all contents of this file is invisible for KPHP
 
+#region constants
+
+define('KPHP_COMPILER_VERSION', '');
+
+#endregion
 
 #region types
 

--- a/vkext.helper.php
+++ b/vkext.helper.php
@@ -26,8 +26,6 @@
 
 #ifndef KPHP
 
-define('KPHP_COMPILER_VERSION', '');
-
 /**
  * Converts string in utf8 to string in cp1251 with html-entities.
  *


### PR DESCRIPTION
Motivation: KPHP_COMPILER_VERSION is an polyfill, not a hint for IDE

Reasoning: 
running using plain PHP with php-polyfills:
```php

echo "KPHP_COMPILER_VERSION;

``` 
Expected behaviour: no errors or warnings.

Actual behaviour:
```
PHP Warning:  Use of undefined constant KPHP_COMPILER_VERSION - assumed 'KPHP_COMPILER_VERSION' (this will throw an Error in a future version of PHP)
```

This PR fixes it.