### PR TITLE
Improved type checking in PHP mode

### DIFF
--- a/kphp_checks.php
+++ b/kphp_checks.php
@@ -1,0 +1,42 @@
+<?php
+
+#ifndef KPHP
+
+function typeof($arg)
+{
+	return get_class($arg);
+}
+
+
+function kphp_polyfill_getDeclaredProps($v, array &$errors):array
+{
+	$errors = [];
+	$refClass = new ReflectionClass($v);
+	$declaredProps = [];
+	foreach ( $refClass->getProperties(ReflectionProperty::IS_PUBLIC|ReflectionProperty::IS_PROTECTED|ReflectionProperty::IS_PRIVATE) as $prop ) {
+		$declaredProps[$prop->name] = 1;
+	};
+	return $declaredProps;
+}
+function kphp_polyfill_checkPropExists(?array &$declaredProps, string $propName, $value, array &$errors)
+{
+	if (!isset($declaredProps[$propName])) {
+		$type = gettype($value);
+		$errors [] = "public $type \$$propName = null;";
+	}
+}
+function kphp_polyfill_verifyProps($v, array $errors)
+{
+	if  (count($errors)) {
+		throw new Exception("Fields not declared as property in ".get_class($v) ."\n".implode("\n", $errors));
+	}
+}
+
+function kphp_polyfill_checkInstance(?object $instance, string $class_name)
+{
+	if  ($instance && ! ($instance instanceof $class_name)) {
+		throw new Exception("Can't cast instance of ".get_class($instance) ." to class $class_name.");
+	}
+}
+#endif
+


### PR DESCRIPTION
Added checks to catch errors invisible on KPHP change affects to behavior.

also:  added typeof() for generics

1. check hierarchy structure in **instance_cast().** 

2. Check property exists and generate property declaration in **to_array_debug()**

3. instance_to_array() must return only PUBLIC properties because used for json_encode(). Any private properties cannot be serialized anyway.
