### PR TITLE
Serialization: do not wrap nullable types with extra parentheses.

### DIFF
--- a/src/InstanceSerialization/PHPDocType.php
+++ b/src/InstanceSerialization/PHPDocType.php
@@ -48,7 +48,7 @@ abstract class PHPDocType {
 
   protected static function parseImpl(string &$str): ?PHPDocType {
     if (self::removeIfStartsWith($str, "?")) {
-      $str = "null|({$str})";
+      $str = "null|{$str}";
     }
 
     $res = InstanceType::parse($str) ?:


### PR DESCRIPTION
This PR fixes case when class' field has type of `array` with nullable elements, like `(?string)[]`.

Currently, when the parser's coming to the `?` symbol it wraps everything at the right side into parentheses, so when it comes to `?string)[]` (note that first `(` is already dropped) it turns it into `null|string)[])` which is actually invalid type.

Nullability via `?` is equivalent to `null|`, no there's no necessity to wrap type into extra parentheses.