### PR TITLE
Serialization: allow `null` in `instance_serialize`.

### DIFF
--- a/kphp_polyfills.php
+++ b/kphp_polyfills.php
@@ -638,7 +638,7 @@ function _php_serialize_helper_run_or_warning(callable $fun) {
   }
 }
 
-function instance_serialize(object $instance): ?string {
+function instance_serialize(?object $instance): ?string {
   KPHP\InstanceSerialization\ClassTransformer::$depth = 0;
   return _php_serialize_helper_run_or_warning(static function() use ($instance) {
     $packer = (new MessagePack\Packer(MessagePack\PackOptions::FORCE_STR))->extendWith(new KPHP\InstanceSerialization\ClassTransformer());


### PR DESCRIPTION
There's no limitation for `null` in `msgpack` serialization, so allow `instance_serialize` to accept `null`.