### PR TITLE
Refactor msgpack

### DIFF
--- a/kphp_polyfills.php
+++ b/kphp_polyfills.php
@@ -650,7 +650,7 @@ function instance_deserialize(string $packed_str, string $type_of_instance): ?ob
   return _php_serialize_helper_run_or_warning(static function() use ($packed_str, $type_of_instance) {
     $unpacked_array = msgpack_deserialize_safe($packed_str);
 
-    $instance_parser = new KPHP\MsgPackSerialization\InstanceDeserializer($type_of_instance);
+    $instance_parser = new KPHP\MsgPackSerialization\MsgPackDeserializer($type_of_instance);
     return $instance_parser->fromUnpackedArray($unpacked_array);
   });
 }

--- a/kphp_polyfills.php
+++ b/kphp_polyfills.php
@@ -639,9 +639,9 @@ function _php_serialize_helper_run_or_warning(callable $fun) {
 }
 
 function instance_serialize(object $instance): ?string {
-  KPHP\InstanceSerialization\ClassTransformer::$depth = 0;
+  KPHP\MsgPackSerialization\ClassTransformer::$depth = 0;
   return _php_serialize_helper_run_or_warning(static function() use ($instance) {
-    $packer = (new MessagePack\Packer(MessagePack\PackOptions::FORCE_STR))->extendWith(new KPHP\InstanceSerialization\ClassTransformer());
+    $packer = (new MessagePack\Packer(MessagePack\PackOptions::FORCE_STR))->extendWith(new KPHP\MsgPackSerialization\ClassTransformer());
     return $packer->pack($instance);
   });
 }
@@ -650,7 +650,7 @@ function instance_deserialize(string $packed_str, string $type_of_instance): ?ob
   return _php_serialize_helper_run_or_warning(static function() use ($packed_str, $type_of_instance) {
     $unpacked_array = msgpack_deserialize_safe($packed_str);
 
-    $instance_parser = new KPHP\InstanceSerialization\InstanceDeserializer($type_of_instance);
+    $instance_parser = new KPHP\MsgPackSerialization\InstanceDeserializer($type_of_instance);
     return $instance_parser->fromUnpackedArray($unpacked_array);
   });
 }

--- a/src/MsgPackSerialization/ClassTransformer.php
+++ b/src/MsgPackSerialization/ClassTransformer.php
@@ -32,7 +32,7 @@ class ClassTransformer implements CanPack {
       $packer = (new Packer(PackOptions::FORCE_STR | PackOptions::FORCE_FLOAT32))->extendWith(new ClassTransformer());
       return $packer->pack($instance->value);
     }
-    $instance_parser = new InstanceSerializer($instance);
+    $instance_parser = new MsgPackSerializer($instance);
     return $packer->pack($instance_parser->tags_values);
   }
 }

--- a/src/MsgPackSerialization/ClassTransformer.php
+++ b/src/MsgPackSerialization/ClassTransformer.php
@@ -7,7 +7,7 @@
 /** @noinspection KphpReturnTypeMismatchInspection */
 /** @noinspection KphpParameterTypeMismatchInspection */
 
-namespace KPHP\InstanceSerialization;
+namespace KPHP\MsgPackSerialization;
 
 use MessagePack\Packer;
 use MessagePack\TypeTransformer\CanPack;

--- a/src/MsgPackSerialization/DeepForceFloat32.php
+++ b/src/MsgPackSerialization/DeepForceFloat32.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace KPHP\InstanceSerialization;
+namespace KPHP\MsgPackSerialization;
 
 class DeepForceFloat32 {
   /**@var any*/

--- a/src/MsgPackSerialization/FieldMetadata.php
+++ b/src/MsgPackSerialization/FieldMetadata.php
@@ -1,6 +1,6 @@
 <?php
 // Compiler for PHP (aka KPHP) polyfills
-// Copyright (c) 2020 LLC �V Kontakte�
+// Copyright (c) 2020 LLC «V Kontakte»
 // Distributed under the GPL v3 License, see LICENSE.notice.txt
 
 namespace KPHP\MsgPackSerialization;

--- a/src/MsgPackSerialization/FieldMetadata.php
+++ b/src/MsgPackSerialization/FieldMetadata.php
@@ -1,9 +1,11 @@
 <?php
 // Compiler for PHP (aka KPHP) polyfills
-// Copyright (c) 2020 LLC «V Kontakte»
+// Copyright (c) 2020 LLC ï¿½V Kontakteï¿½
 // Distributed under the GPL v3 License, see LICENSE.notice.txt
 
-namespace KPHP\InstanceSerialization;
+namespace KPHP\MsgPackSerialization;
+
+use KPHP\PhpDocParsing\PhpDocType;
 
 class FieldMetadata {
   /** @var int */

--- a/src/MsgPackSerialization/InstanceDeserializer.php
+++ b/src/MsgPackSerialization/InstanceDeserializer.php
@@ -1,13 +1,13 @@
 <?php
 // Compiler for PHP (aka KPHP) polyfills
-// Copyright (c) 2020 LLC «V Kontakte»
+// Copyright (c) 2020 LLC ï¿½V Kontakteï¿½
 // Distributed under the GPL v3 License, see LICENSE.notice.txt
 
 /** @noinspection NoTypeDeclarationInspection */
 /** @noinspection KphpReturnTypeMismatchInspection */
 /** @noinspection KphpParameterTypeMismatchInspection */
 
-namespace KPHP\InstanceSerialization;
+namespace KPHP\MsgPackSerialization;
 
 use ReflectionClass;
 use ReflectionException;

--- a/src/MsgPackSerialization/InstanceMetadata.php
+++ b/src/MsgPackSerialization/InstanceMetadata.php
@@ -7,8 +7,10 @@
 /** @noinspection KphpReturnTypeMismatchInspection */
 /** @noinspection KphpParameterTypeMismatchInspection */
 
-namespace KPHP\InstanceSerialization;
+namespace KPHP\MsgPackSerialization;
 
+use KPHP\PhpDocParsing\PhpDocType;
+use KPHP\PhpDocParsing\UseResolver;
 use ReflectionClass;
 use ReflectionException;
 use RuntimeException;
@@ -28,7 +30,7 @@ class InstanceMetadata {
    * @throws RuntimeException
    */
   public function __construct(string $instance) {
-    assert(is_string($instance) && $instance !== '' && $instance !== 'self');
+    assert($instance !== '' && $instance !== 'self');
     $this->reflection_of_instance = new ReflectionClass($instance);
     $this->use_resolver           = new UseResolver($this->reflection_of_instance);
 

--- a/src/MsgPackSerialization/InstanceMetadataCache.php
+++ b/src/MsgPackSerialization/InstanceMetadataCache.php
@@ -7,7 +7,7 @@
 /** @noinspection KphpReturnTypeMismatchInspection */
 /** @noinspection KphpParameterTypeMismatchInspection */
 
-namespace KPHP\InstanceSerialization;
+namespace KPHP\MsgPackSerialization;
 
 use ReflectionException;
 

--- a/src/MsgPackSerialization/InstanceMetadataCache.php
+++ b/src/MsgPackSerialization/InstanceMetadataCache.php
@@ -14,13 +14,10 @@ use ReflectionException;
 class InstanceMetadataCache {
 
   /** @var InstanceMetadata[] */
-  private static $instance_parsers = [];
+  private static array $cached_classes = [];
 
   /** @throws ReflectionException */
   public static function getInstanceMetadata(string $class_name): InstanceMetadata {
-    if (!array_key_exists($class_name, self::$instance_parsers)) {
-      self::$instance_parsers[$class_name] = new InstanceMetadata($class_name);
-    }
-    return self::$instance_parsers[$class_name];
+    return self::$cached_classes[$class_name] ??= new InstanceMetadata($class_name);
   }
 }

--- a/src/MsgPackSerialization/InstanceSerializer.php
+++ b/src/MsgPackSerialization/InstanceSerializer.php
@@ -7,7 +7,7 @@
 /** @noinspection KphpReturnTypeMismatchInspection */
 /** @noinspection KphpParameterTypeMismatchInspection */
 
-namespace KPHP\InstanceSerialization;
+namespace KPHP\MsgPackSerialization;
 
 use ReflectionException;
 use RuntimeException;

--- a/src/MsgPackSerialization/MsgPackDeserializer.php
+++ b/src/MsgPackSerialization/MsgPackDeserializer.php
@@ -1,6 +1,6 @@
 <?php
 // Compiler for PHP (aka KPHP) polyfills
-// Copyright (c) 2020 LLC �V Kontakte�
+// Copyright (c) 2020 LLC «V Kontakte»
 // Distributed under the GPL v3 License, see LICENSE.notice.txt
 
 /** @noinspection NoTypeDeclarationInspection */
@@ -14,7 +14,7 @@ use ReflectionException;
 use ReflectionProperty;
 use RuntimeException;
 
-class InstanceDeserializer {
+class MsgPackDeserializer {
   /** @var InstanceMetadata */
   public $instance_metadata;
 
@@ -41,7 +41,7 @@ class InstanceDeserializer {
       throw new RuntimeException('Expected NIL or ARRAY type for unpacking class_instance');
     }
 
-    $instance        = $this->instance_metadata->reflection_of_instance->newInstanceWithoutConstructor();
+    $instance        = $this->instance_metadata->klass->newInstanceWithoutConstructor();
     $rc_for_instance = new ReflectionClass($instance);
 
     for ($i = 0, $i_max = count($unpacked_arr); $i < $i_max; $i += 2) {

--- a/src/MsgPackSerialization/MsgPackDeserializer.php
+++ b/src/MsgPackSerialization/MsgPackDeserializer.php
@@ -37,10 +37,6 @@ class MsgPackDeserializer {
       return null;
     }
 
-    if (!is_array($unpacked_arr)) {
-      throw new RuntimeException('Expected NIL or ARRAY type for unpacking class_instance');
-    }
-
     $instance        = $this->instance_metadata->klass->newInstanceWithoutConstructor();
     $rc_for_instance = new ReflectionClass($instance);
 
@@ -50,7 +46,7 @@ class MsgPackDeserializer {
 
       foreach ($this->instance_metadata->fields_data as $field) {
         if ($field->id == $cur_tag) {
-          $value = $field->phpdoc_type->fromUnpackedValue($value, $this->instance_metadata->use_resolver);
+          $value = $field->phpdoc_type->fromUnpackedValue($value);
 
           $property = $rc_for_instance->getProperty($field->name);
           $property->setAccessible(true);

--- a/src/MsgPackSerialization/MsgPackSerializer.php
+++ b/src/MsgPackSerialization/MsgPackSerializer.php
@@ -12,7 +12,7 @@ namespace KPHP\MsgPackSerialization;
 use ReflectionException;
 use RuntimeException;
 
-class InstanceSerializer {
+class MsgPackSerializer {
   /**@var (mixed|DeepForceFloat32)[] */
   public $tags_values = [];
 
@@ -59,7 +59,7 @@ class InstanceSerializer {
    * @throws ReflectionException
    */
   private function getValue(FieldMetadata $field, object $instance) {
-    $property = $this->instance_metadata->reflection_of_instance->getProperty($field->name);
+    $property = $this->instance_metadata->klass->getProperty($field->name);
     $property->setAccessible(true);
     return $property->getValue($instance);
   }

--- a/src/MsgPackSerialization/MsgPackSerializer.php
+++ b/src/MsgPackSerialization/MsgPackSerializer.php
@@ -45,12 +45,13 @@ class MsgPackSerializer {
   /** @param mixed $value */
   private function checkTypeOf(FieldMetadata $field, $value): void {
     try {
-      $field->phpdoc_type->verifyValue($value, $this->instance_metadata->use_resolver);
+      $field->phpdoc_type->verifyValue($value);
     } catch (RuntimeException $e) {
       if (ClassTransformer::$depth > ClassTransformer::$max_depth) {
         throw $e;
       }
-      throw new RuntimeException("in field: `{$field->name}` -> " . $e->getMessage(), 0);
+      $class_name = $this->instance_metadata->klass->name;
+      throw new RuntimeException("in field $class_name::\${$field->name}: " . $e->getMessage());
     }
   }
 

--- a/src/PhpDocParsing/ArrayType.php
+++ b/src/PhpDocParsing/ArrayType.php
@@ -7,25 +7,25 @@
 /** @noinspection KphpReturnTypeMismatchInspection */
 /** @noinspection KphpParameterTypeMismatchInspection */
 
-namespace KPHP\InstanceSerialization;
+namespace KPHP\PhpDocParsing;
 
 use RuntimeException;
 
-class ArrayType extends PHPDocType {
-  /**@var ?PHPDocType */
+class ArrayType extends PhpDocType {
+  /**@var ?PhpDocType */
   public $inner_type = null;
 
   /**@var int */
   public $cnt_arrays = 0;
 
-  public function __construct(PHPDocType $inner_type, int $cnt_arrays) {
+  public function __construct(PhpDocType $inner_type, int $cnt_arrays) {
     $this->inner_type = $inner_type;
     $this->cnt_arrays = $cnt_arrays;
   }
 
-  protected static function parseImpl(string &$str): ?PHPDocType {
+  protected static function parseImpl(string &$str): ?PhpDocType {
     if (parent::removeIfStartsWith($str, '(')) {
-      $inner_type = PHPDocType::parse($str);
+      $inner_type = PhpDocType::parse($str);
       assert($inner_type && $str[0] === ')');
       $str = ltrim(substr($str, 1));
     } else {

--- a/src/PhpDocParsing/InstanceType.php
+++ b/src/PhpDocParsing/InstanceType.php
@@ -9,6 +9,8 @@
 
 namespace KPHP\PhpDocParsing;
 
+use KPHP\MsgPackSerialization\MsgPackDeserializer;
+use KPHP\MsgPackSerialization\MsgPackSerializer;
 use ReflectionClass;
 use ReflectionException;
 use RuntimeException;
@@ -40,7 +42,7 @@ class InstanceType extends PhpDocType {
    */
   public function fromUnpackedValue($value, UseResolver $use_resolver) {
     $resolved_class_name = $this->getResolvedClassName($use_resolver);
-    $parser              = new InstanceDeserializer($resolved_class_name);
+    $parser              = new MsgPackDeserializer($resolved_class_name);
     return $parser->fromUnpackedArray($value);
   }
 
@@ -67,8 +69,8 @@ class InstanceType extends PhpDocType {
 
     $resolved_name = $this->getResolvedClassName($use_resolver);
     $rc            = new ReflectionClass($resolved_name);
-    $parser        = new InstanceSerializer($value); // will verify values inside $value
-    if ($parser->instance_metadata->reflection_of_instance->getName() !== $rc->getName()) {
+    $parser        = new MsgPackSerializer($value); // will verify values inside $value
+    if ($parser->instance_metadata->klass->getName() !== $rc->getName()) {
       self::throwRuntimeException($rc->getName(), $this->type);
     }
   }

--- a/src/PhpDocParsing/InstanceType.php
+++ b/src/PhpDocParsing/InstanceType.php
@@ -7,17 +7,17 @@
 /** @noinspection KphpReturnTypeMismatchInspection */
 /** @noinspection KphpParameterTypeMismatchInspection */
 
-namespace KPHP\InstanceSerialization;
+namespace KPHP\PhpDocParsing;
 
 use ReflectionClass;
 use ReflectionException;
 use RuntimeException;
 
-class InstanceType extends PHPDocType {
+class InstanceType extends PhpDocType {
   /**@var string */
   public $type = '';
 
-  protected static function parseImpl(string &$str): ?PHPDocType {
+  protected static function parseImpl(string &$str): ?PhpDocType {
     if (preg_match('/^(\\\\?[A-Z][a-zA-Z0-9_\x80-\xff\\\\]*|self|static|object)/', $str, $matches)) {
       $res       = new self();
       $res->type = $matches[1];

--- a/src/PhpDocParsing/OrType.php
+++ b/src/PhpDocParsing/OrType.php
@@ -7,21 +7,21 @@
 /** @noinspection KphpReturnTypeMismatchInspection */
 /** @noinspection KphpParameterTypeMismatchInspection */
 
-namespace KPHP\InstanceSerialization;
+namespace KPHP\PhpDocParsing;
 
 use Throwable;
 
-class OrType extends PHPDocType {
-  /**@var PHPDocType */
+class OrType extends PhpDocType {
+  /**@var PhpDocType */
   public $type1;
 
-  /**@var PHPDocType */
+  /**@var PhpDocType */
   public $type2;
 
-  protected static function parseImpl(string &$str): ?PHPDocType {
+  protected static function parseImpl(string &$str): ?PhpDocType {
     if (parent::removeIfStartsWith($str, '|')) {
       $res        = new self();
-      $res->type2 = PHPDocType::parse($str);
+      $res->type2 = PhpDocType::parse($str);
       return $res;
     }
 

--- a/src/PhpDocParsing/OrType.php
+++ b/src/PhpDocParsing/OrType.php
@@ -12,35 +12,36 @@ namespace KPHP\PhpDocParsing;
 use Throwable;
 
 class OrType extends PhpDocType {
-  /**@var PhpDocType */
-  public $type1;
+  public PhpDocType $type1;
+  public PhpDocType $type2;
 
-  /**@var PhpDocType */
-  public $type2;
-
-  protected static function parseImpl(string &$str): ?PhpDocType {
+  protected static function parseImpl(string &$str, UseResolver $use_resolver): ?PhpDocType {
     if (parent::removeIfStartsWith($str, '|')) {
+      $type2 = PhpDocType::parse($str, $use_resolver);
+      if ($type2 === null) {
+        return null;
+      }
       $res        = new self();
-      $res->type2 = PhpDocType::parse($str);
+      $res->type2 = $type2;
       return $res;
     }
 
     return null;
   }
 
-  public function fromUnpackedValue($value, UseResolver $use_resolver) {
+  public function fromUnpackedValue($value) {
     try {
-      return $this->type1->fromUnpackedValue($value, $use_resolver);
+      return $this->type1->fromUnpackedValue($value);
     } catch (Throwable $_) {
-      return $this->type2->fromUnpackedValue($value, $use_resolver);
+      return $this->type2->fromUnpackedValue($value);
     }
   }
 
-  public function verifyValue($value, UseResolver $use_resolver): void {
+  public function verifyValue($value): void {
     try {
-      $this->type1->verifyValue($value, $use_resolver);
+      $this->type1->verifyValue($value);
     } catch (Throwable $_) {
-      $this->type2->verifyValue($value, $use_resolver);
+      $this->type2->verifyValue($value);
     }
   }
 

--- a/src/PhpDocParsing/PhpDocType.php
+++ b/src/PhpDocParsing/PhpDocType.php
@@ -33,9 +33,9 @@ abstract class PhpDocType {
                       "?" PHPDocType |
   */
   public static function throwRuntimeException($value, $type): void {
-    $value = vk_json_encode($value);
-    $type  = vk_json_encode($type);
-    throw new RuntimeException("value: `${value}` doesn't correspond to type: `${type}`");
+    $value_str = str_replace("\n", " ", substr(var_export($value, true), 0, 100));
+    $type_str  = var_export($type, true);
+    throw new RuntimeException("can't assign to type $type_str from $value_str");
   }
 
   protected static function removeIfStartsWith(string &$haystack, $needle): bool {
@@ -46,35 +46,32 @@ abstract class PhpDocType {
     return false;
   }
 
-  protected static function parseImpl(string &$str): ?PHPDocType {
+  protected static function parseImpl(string &$str, UseResolver $use_resolver): ?PHPDocType {
     $nullable = self::removeIfStartsWith($str, "?");
 
-    $res = InstanceType::parse($str) ?:
-           PrimitiveType::parse($str) ?:
-           TupleType::parse($str) ?:
-           ArrayType::parse($str);
+    $res = InstanceType::parse($str, $use_resolver) ?:
+           PrimitiveType::parse($str, $use_resolver) ?:
+           TupleType::parse($str, $use_resolver) ?:
+           ArrayType::parse($str, $use_resolver);
 
     if (!$res) {
       return null;
     }
 
-    $cnt_arrays = ArrayType::parseArrays($str);
-    if ($cnt_arrays) {
-      $res = new ArrayType($res, $cnt_arrays);
+    while (self::removeIfStartsWith($str, '[]')) {
+      $res = new ArrayType($res);
     }
 
     /**@var OrType */
-    $or_type = OrType::parse($str);
+    $or_type = OrType::parse($str, $use_resolver);
     if ($or_type) {
       $or_type->type1 = $res;
       $res            = $or_type;
     }
 
     if ($nullable) {
-      $null = new PrimitiveType();
-      $null->type = 'null';
       $or_type = new OrType();
-      $or_type->type1 = $null;
+      $or_type->type1 = new PrimitiveType('null');
       $or_type->type2 = $res;
       $res = $or_type;
     }
@@ -82,9 +79,9 @@ abstract class PhpDocType {
     return $res;
   }
 
-  public static function parse(string &$str): ?PhpDocType {
+  public static function parse(string &$str, UseResolver $use_resolver): ?PhpDocType {
     $str = ltrim($str);
-    $res = static::parseImpl($str);
+    $res = static::parseImpl($str, $use_resolver);
     $str = ltrim($str);
     return $res;
   }
@@ -94,13 +91,13 @@ abstract class PhpDocType {
    * @return mixed
    * @throws RuntimeException
    */
-  abstract public function fromUnpackedValue($value, UseResolver $use_resolver);
+  abstract public function fromUnpackedValue($value);
 
   /**
    * @param mixed $value
    * @throws RuntimeException
    */
-  abstract public function verifyValue($value, UseResolver $use_resolver): void;
+  abstract public function verifyValue($value): void;
 
   abstract protected function hasInstanceInside(): bool;
 }

--- a/src/PhpDocParsing/PhpDocType.php
+++ b/src/PhpDocParsing/PhpDocType.php
@@ -46,10 +46,8 @@ abstract class PhpDocType {
     return false;
   }
 
-  protected static function parseImpl(string &$str): ?PhpDocType {
-    if (self::removeIfStartsWith($str, "?")) {
-      $str = "null|({$str})";
-    }
+  protected static function parseImpl(string &$str): ?PHPDocType {
+    $nullable = self::removeIfStartsWith($str, "?");
 
     $res = InstanceType::parse($str) ?:
            PrimitiveType::parse($str) ?:
@@ -70,6 +68,15 @@ abstract class PhpDocType {
     if ($or_type) {
       $or_type->type1 = $res;
       $res            = $or_type;
+    }
+
+    if ($nullable) {
+      $null = new PrimitiveType();
+      $null->type = 'null';
+      $or_type = new OrType();
+      $or_type->type1 = $null;
+      $or_type->type2 = $res;
+      $res = $or_type;
     }
 
     return $res;

--- a/src/PhpDocParsing/PhpDocType.php
+++ b/src/PhpDocParsing/PhpDocType.php
@@ -7,11 +7,11 @@
 /** @noinspection KphpReturnTypeMismatchInspection */
 /** @noinspection KphpParameterTypeMismatchInspection */
 
-namespace KPHP\InstanceSerialization;
+namespace KPHP\PhpDocParsing;
 
 use RuntimeException;
 
-abstract class PHPDocType {
+abstract class PhpDocType {
   /*
     PHPDoc grammar
 
@@ -46,7 +46,7 @@ abstract class PHPDocType {
     return false;
   }
 
-  protected static function parseImpl(string &$str): ?PHPDocType {
+  protected static function parseImpl(string &$str): ?PhpDocType {
     if (self::removeIfStartsWith($str, "?")) {
       $str = "null|({$str})";
     }
@@ -75,7 +75,7 @@ abstract class PHPDocType {
     return $res;
   }
 
-  public static function parse(string &$str): ?PHPDocType {
+  public static function parse(string &$str): ?PhpDocType {
     $str = ltrim($str);
     $res = static::parseImpl($str);
     $str = ltrim($str);

--- a/src/PhpDocParsing/PrimitiveType.php
+++ b/src/PhpDocParsing/PrimitiveType.php
@@ -7,11 +7,11 @@
 /** @noinspection KphpReturnTypeMismatchInspection */
 /** @noinspection KphpParameterTypeMismatchInspection */
 
-namespace KPHP\InstanceSerialization;
+namespace KPHP\PhpDocParsing;
 
 use RuntimeException;
 
-class PrimitiveType extends PHPDocType {
+class PrimitiveType extends PhpDocType {
   /**@var string[] */
   public static $primitive_types = [
     'int', 'integer', 'float',
@@ -23,7 +23,7 @@ class PrimitiveType extends PHPDocType {
   /**@var string */
   public $type = '';
 
-  protected static function parseImpl(string &$str): ?PHPDocType {
+  protected static function parseImpl(string &$str): ?PhpDocType {
     foreach (self::$primitive_types as $primitive_type) {
       if (self::removeIfStartsWith($str, $primitive_type)) {
         $res       = new self();

--- a/src/PhpDocParsing/TupleType.php
+++ b/src/PhpDocParsing/TupleType.php
@@ -7,28 +7,28 @@
 /** @noinspection KphpReturnTypeMismatchInspection */
 /** @noinspection KphpParameterTypeMismatchInspection */
 
-namespace KPHP\InstanceSerialization;
+namespace KPHP\PhpDocParsing;
 
 use RuntimeException;
 
-class TupleType extends PHPDocType {
-  /**@var PHPDocType[] */
+class TupleType extends PhpDocType {
+  /**@var PhpDocType[] */
   public $types = [];
 
-  /** @param PHPDocType[] $types */
+  /** @param PhpDocType[] $types */
   public function __construct(array $types) {
     $this->types = $types;
   }
 
   /** @throws RuntimeException */
-  protected static function parseImpl(string &$str): ?PHPDocType {
+  protected static function parseImpl(string &$str): ?PhpDocType {
     if (!parent::removeIfStartsWith($str, '\\tuple(') && !parent::removeIfStartsWith($str, 'tuple(')) {
       return null;
     }
 
     $types = [];
     while (true) {
-      $cur_type = PHPDocType::parse($str);
+      $cur_type = PhpDocType::parse($str);
       if (!$cur_type) {
         throw new RuntimeException('something went wrong in parsing tuple phpdoc');
       }
@@ -71,7 +71,7 @@ class TupleType extends PHPDocType {
   }
 
   protected function hasInstanceInside(): bool {
-    return in_array(true, array_map(fn(PHPDocType $type) => $type->hasInstanceInside(), $this->types), true);
+    return in_array(true, array_map(fn(PhpDocType $type) => $type->hasInstanceInside(), $this->types), true);
   }
 
   /** @param mixed $value */

--- a/src/PhpDocParsing/UseResolver.php
+++ b/src/PhpDocParsing/UseResolver.php
@@ -7,7 +7,7 @@
 /** @noinspection KphpReturnTypeMismatchInspection */
 /** @noinspection KphpParameterTypeMismatchInspection */
 
-namespace KPHP\InstanceSerialization;
+namespace KPHP\PhpDocParsing;
 
 use ReflectionClass;
 use SplFileObject;

--- a/src/PhpDocParsing/UseResolver.php
+++ b/src/PhpDocParsing/UseResolver.php
@@ -109,21 +109,21 @@ class UseResolver {
     return [$alias, $class_name];
   }
 
-  public function resolveName(string $instance_name): string {
-    if ($instance_name[0] === '\\') {
-      return $instance_name;
+  public function resolveName(string $relative): string {
+    if ($relative[0] === '\\') {
+      return $relative;
     }
 
-    if ($instance_name === 'self') {
+    if ($relative === 'self') {
       return $this->instance_reflection->getName();
     }
 
-    $backslash_position = strpos($instance_name, '\\') ?: strlen($instance_name);
-    $first_part_of_name = substr($instance_name, 0, $backslash_position);
+    $backslash_position = strpos($relative, '\\') ?: strlen($relative);
+    $first_part_of_name = substr($relative, 0, $backslash_position);
     if (isset($this->alias_to_name[$first_part_of_name])) {
-      return $this->alias_to_name[$first_part_of_name] . substr($instance_name, strlen($first_part_of_name));
+      return $this->alias_to_name[$first_part_of_name] . substr($relative, strlen($first_part_of_name));
     }
 
-    return $this->instance_reflection->getNamespaceName() . '\\' . $instance_name;
+    return $this->instance_reflection->getNamespaceName() . '\\' . $relative;
   }
 }


### PR DESCRIPTION
Split namespace `InstanceSerialization` into `MsgPackSerialization` and `PhpDocParsing` + some renamings.
Improvements of phpdoc parsing:
* 'array' is 'any[]'
* drop cnt_arrays, nested arrays are a real tree structure now
* resolve uses while parsing, not while applying values