### PR TITLE
kphp-tracing polyfills

### DIFF
--- a/kphp_polyfills.php
+++ b/kphp_polyfills.php
@@ -1313,7 +1313,7 @@ final class KphpDiv {
     return tuple(0, 0);
   }
 
-  public function assignTraceCtx(int $int1, int $int2, int $override_div_id): int {
+  public function assignTraceCtx(int $int1, int $int2, ?int $override_div_id): int {
     return 0;
   }
 


### PR DESCRIPTION
KPHP tracing is a technology that aims to collect richer variety of data compared to Open telemetry and faster compared to existing tracing SDKs.

KPHP tracing is not implemented for PHP at all (and has no reason to be).
In PHP, all tracing functions do nothing.

PR for tracing into KPHP will be created soon.